### PR TITLE
`remaining_voting_periods` major change

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,15 +1,4 @@
-# 2020-04-04
-
-### SECURITY AUDIT FIXES
-
-- retain ineligible votes
-  - do not delete votes when voter becomes ineligible in `refresh_proposal()`
-  - handle ineligible producers in `calculate_total_net_votes()`
-  - simplify `refresh_proposal()`
-  - allows voters to `comment()` if no longer eligible
-- add `calculate_producer_per_vote_pay` helper method
-
-# 2020-04-02
+# 2020-04-02 to 2020-04-09
 
 ### SECURITY AUDIT FIXES
 
@@ -26,6 +15,33 @@
 - remove `update_eligible_proposals()` executing a second time at `complete`
 - fix `set_pending_to_active()` to modify multiple rows
 - add explicite check for to prevent having above 100 active proposals
+- retain ineligible votes
+  - do not delete votes when voter becomes ineligible in `refresh_proposal()`
+  - handle ineligible producers in `calculate_total_net_votes()`
+  - simplify `refresh_proposal()`
+  - allows voters to `comment()` if no longer eligible
+- add `calculate_producer_per_vote_pay` helper method
+
+#### `remaining_voting_periods` major change
+
+- remove `proposals::end` value
+- add `proposals::remaining_voting_periods` number which represent how many remaining of voting periods the proposal has.
+- when proposal `activate` the `remaining_voting_periods` is set to the `duration` (for both active & pending proposals)
+- whenever `complete` is executed, all `active` proposals will reduce -1 the `remaining_voting_periods`, `pending` proposals are unchanged.
+- any proposals that have 0 duration are set to either `completed`/`expired`/`partial`
+- replace `start_voting_period` from `activate()` and replace with `bool activate_next`
+- don't add future or past proposals to `periods`
+- when `complete` add all `active` & `pending` proposal names to `periods`
+- only include `pending` proposals to `periods` when active
+- set `start_voting_period` = 0 for `pending` proposals
+- when `complete` update current & next voting periods to 0:00 UTC (in case multiple days/weeks are skipped, the current voting period will be set to the day the last `complete` is executed).
+- set `start_voting_period` for proposals changing from `pending` => `active`
+
+#### Breaking UI changes
+
+- replace `start_voting_period` from `activate()` ACTION and replace with `bool activate_next` (true = activate next, false = active current)
+- replace `end` value with `remaining_voting_periods` in `proposals` TABLE
+- `remaining_voting_periods` number represents how many remaining of voting periods the proposal has.
 
 # 2020-03-29
 

--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ Activate WPS proposal at a specified voting period
 
 - `{name} proposer` - proposer
 - `{name} proposal_name` - proposal name
-- `{time_point_sec} start_voting_period` - activate proposal at the specified voting period (must be current or next)
+- `{bool} [activate_next=false]` - (optional) activate proposal at next voting period (default to current voting period)
 
 ```bash
-cleos push action eosio.wps activate '["myaccount", "mywps", "2019-11-25T00:00:00"]' -p myaccount
+cleos push action eosio.wps activate '["myaccount", "mywps", false]' -p myaccount
 ```
 
 ## ACTION `claim`

--- a/TO-DO.md
+++ b/TO-DO.md
@@ -10,15 +10,12 @@
 - [x] whenever `complete` is executed, all `active` proposals will reduce -1 the `remaining_voting_periods`, `pending` proposals are unchanged.
 - [x] any proposals that have 0 duration are set to either `completed`/`expired`/`partial`
 - [x] replace `start_voting_period` from `activate()` and replace with `bool activate_next`
-- [ ] don't add future or past proposals to `periods`
-- [ ] when `complete` add all `active` & `pending` proposal names to `periods`
-- [ ] only include `pending` proposals to `periods` when active
-- [ ] set `start_voting_period` = 0 for `pending` proposals
-- [ ] when `complete` update current & next voting periods to 0:00 UTC (in case multiple days/weeks are skipped, the current voting period will be set to the day the last `complete` is executed).
-- [ ] add date/hour/min to when `complete` is finished
-- [ ] remove `state::next_voting_period` row (no longer used)
+- [x] don't add future or past proposals to `periods`
+- [x] when `complete` add all `active` & `pending` proposal names to `periods`
+- [x] only include `pending` proposals to `periods` when active
+- [x] set `start_voting_period` = 0 for `pending` proposals
+- [x] when `complete` update current & next voting periods to 0:00 UTC (in case multiple days/weeks are skipped, the current voting period will be set to the day the last `complete` is executed).
 - [x] set `start_voting_period` for proposals changing from `pending` => `active`
-
 
 ## Optional
 

--- a/TO-DO.md
+++ b/TO-DO.md
@@ -4,16 +4,15 @@
 
 ## major changes
 
-- remove `end` params from `proposals`
-- add `remaining_voting_periods` integer in `proposals` (ex: number of voting periods requested)
-- when proposal `activate` they start as `active` and -1 from their requested duration
-- when proposal `activate` NEXT, their proposal is set to `pending` and `remaining_voting_periods` == `duration`
-- whenever `complete` is executed, all `active` proposals will reduce -1 the `remaining_voting_periods`, `pending` proposals are set to `active` using the requested duration.
-- any proposals that have 0 are set to either `completed` or `expired` (not enough votes)
-- don't add future or past proposals to `periods`
-- when `complete` add all `active` proposal names to `periods`
-- only include `pending` proposals to `periods` when active
-- set `start_voting_period` = 0 for `pending` proposals
+- [x] remove `end` params from `proposals`
+- [x] add `remaining_voting_periods` integer in `proposals` (ex: number of voting periods requested)
+- [x] when proposal `activate` the `remaining_voting_periods` is set to the `duration` (for both active & pending proposals)
+- [ ] whenever `complete` is executed, all `active` proposals will reduce -1 the `remaining_voting_periods`, `pending` proposals are unchanged.
+- [ ] any proposals that have 0 are set to either `completed` or `expired` (not enough votes)
+- [ ] don't add future or past proposals to `periods`
+- [ ] when `complete` add all `active` proposal names to `periods`
+- [ ] only include `pending` proposals to `periods` when active
+- [ ] set `start_voting_period` = 0 for `pending` proposals
 
 ## Optional
 

--- a/TO-DO.md
+++ b/TO-DO.md
@@ -8,11 +8,13 @@
 - [x] add `remaining_voting_periods` integer in `proposals` (ex: number of voting periods requested)
 - [x] when proposal `activate` the `remaining_voting_periods` is set to the `duration` (for both active & pending proposals)
 - [ ] whenever `complete` is executed, all `active` proposals will reduce -1 the `remaining_voting_periods`, `pending` proposals are unchanged.
-- [ ] any proposals that have 0 are set to either `completed` or `expired` (not enough votes)
+- [x] any proposals that have 0 duration are set to either `completed`/`expired`/`partial`
 - [ ] don't add future or past proposals to `periods`
 - [ ] when `complete` add all `active` proposal names to `periods`
 - [ ] only include `pending` proposals to `periods` when active
 - [ ] set `start_voting_period` = 0 for `pending` proposals
+- [ ] when `complete` update current & next voting periods to 0:00 UTC (in case multiple days/weeks are skipped, the current voting period will be set to the day the last `complete` is executed).
+- [ ] add date/hour/min to when `complete` is finished
 
 ## Optional
 

--- a/TO-DO.md
+++ b/TO-DO.md
@@ -2,14 +2,13 @@
 
 - build using RC's
 
-
 ## major changes
 
 - remove `end` params from `proposals`
-- add `remaining_periods` integer in `proposals` (ex: number of voting periods requested)
+- add `remaining_voting_periods` integer in `proposals` (ex: number of voting periods requested)
 - when proposal `activate` they start as `active` and -1 from their requested duration
-- when proposal `activate` NEXT, their proposal is set to `pending` and `remaining_periods` == `duration`
-- whenever `complete` is executed, all `active` proposals will reduce -1 the `remaining_periods`, `pending` proposals are set to `active` using the requested duration.
+- when proposal `activate` NEXT, their proposal is set to `pending` and `remaining_voting_periods` == `duration`
+- whenever `complete` is executed, all `active` proposals will reduce -1 the `remaining_voting_periods`, `pending` proposals are set to `active` using the requested duration.
 - any proposals that have 0 are set to either `completed` or `expired` (not enough votes)
 - don't add future or past proposals to `periods`
 - when `complete` add all `active` proposal names to `periods`

--- a/TO-DO.md
+++ b/TO-DO.md
@@ -7,14 +7,18 @@
 - [x] remove `end` params from `proposals`
 - [x] add `remaining_voting_periods` integer in `proposals` (ex: number of voting periods requested)
 - [x] when proposal `activate` the `remaining_voting_periods` is set to the `duration` (for both active & pending proposals)
-- [ ] whenever `complete` is executed, all `active` proposals will reduce -1 the `remaining_voting_periods`, `pending` proposals are unchanged.
+- [x] whenever `complete` is executed, all `active` proposals will reduce -1 the `remaining_voting_periods`, `pending` proposals are unchanged.
 - [x] any proposals that have 0 duration are set to either `completed`/`expired`/`partial`
+- [x] replace `start_voting_period` from `activate()` and replace with `bool activate_next`
 - [ ] don't add future or past proposals to `periods`
-- [ ] when `complete` add all `active` proposal names to `periods`
+- [ ] when `complete` add all `active` & `pending` proposal names to `periods`
 - [ ] only include `pending` proposals to `periods` when active
 - [ ] set `start_voting_period` = 0 for `pending` proposals
 - [ ] when `complete` update current & next voting periods to 0:00 UTC (in case multiple days/weeks are skipped, the current voting period will be set to the day the last `complete` is executed).
 - [ ] add date/hour/min to when `complete` is finished
+- [ ] remove `state::next_voting_period` row (no longer used)
+- [x] set `start_voting_period` for proposals changing from `pending` => `active`
+
 
 ## Optional
 

--- a/include/eosio.wps/eosio.wps.hpp
+++ b/include/eosio.wps/eosio.wps.hpp
@@ -20,7 +20,7 @@ static constexpr uint64_t MONTH = 2592000; // 30 days
 static constexpr symbol BUDGET_SYMBOL = symbol{"EOS", 4};
 static constexpr name BUDGET_TOKEN_CONTRACT = "eosio.token"_n;
 
-// remove TESTING flag to break all the testing logic
+// set TESTING true/false
 static constexpr bool TESTING = true;
 
 /**
@@ -773,15 +773,18 @@ private:
     // private helpers
     // ===============
 
+    // periods
+    void add_proposal_to_periods( const name proposal_name );
+    void copy_current_to_next_periods();
+    void check_max_number_proposals();
+
     // activate
-    void proposal_to_periods( const name proposal_name, const name ram_payer );
     void check_min_time_voting_end( );
     void check_draft_proposal_exists( const name proposer, const name proposal_name );
     void deduct_proposal_activate_fee( const name proposer );
-    void emplace_proposal_from_draft( const name proposer, const name proposal_name, const bool activate_next, const name ram_payer );
-    void emplace_empty_votes( const name proposal_name, const name ram_payer );
+    void emplace_proposal_from_draft( const name proposer, const name proposal_name, const bool activate_next );
+    void emplace_empty_votes( const name proposal_name );
     void check_eligible_proposer( const name proposer );
-    void check_max_number_proposals();
 
     // vote
     int16_t calculate_total_net_votes( const map<name, name> votes, const set<name> eligible_producers );

--- a/include/eosio.wps/eosio.wps.hpp
+++ b/include/eosio.wps/eosio.wps.hpp
@@ -242,7 +242,7 @@ struct [[eosio::table("proposals"), eosio::contract("eosio.wps")]] proposals_row
     asset                   claimed;
     time_point_sec          created;
     time_point_sec          start_voting_period;
-    time_point_sec          end;
+    int16_t                 remaining_voting_periods;
 
     uint64_t primary_key() const { return proposal_name.value; }
     uint64_t by_status() const { return status.value; }

--- a/include/eosio.wps/eosio.wps.hpp
+++ b/include/eosio.wps/eosio.wps.hpp
@@ -20,6 +20,9 @@ static constexpr uint64_t MONTH = 2592000; // 30 days
 static constexpr symbol BUDGET_SYMBOL = symbol{"EOS", 4};
 static constexpr name BUDGET_TOKEN_CONTRACT = "eosio.token"_n;
 
+// remove TESTING flag to break all the testing logic
+static constexpr bool TESTING = true;
+
 /**
  * ## TABLE `settings`
  *

--- a/include/eosio.wps/eosio.wps.hpp
+++ b/include/eosio.wps/eosio.wps.hpp
@@ -518,14 +518,14 @@ public:
      *
      * - `{name} proposer` - proposer
      * - `{name} proposal_name` - proposal name
-     * - `{time_point_sec} [start_voting_period=null]` - (optional) activate proposal at the specified voting period (must be current or next)
+     * - `{bool} [activate_next=false]` - (optional) activate proposal at next voting period (default to current voting period)
      *
      * ```bash
-     * cleos push action eosio.wps activate '["myaccount", "mywps", "2019-11-25T00:00:00"]' -p myaccount
+     * cleos push action eosio.wps activate '["myaccount", "mywps", false]' -p myaccount
      * ```
      */
     [[eosio::action]]
-    void activate( const name proposer, const name proposal_name, const optional<time_point_sec> start_voting_period );
+    void activate( const name proposer, const name proposal_name, const bool activate_next );
 
     /**
      * ## ACTION `refund`
@@ -775,12 +775,11 @@ private:
 
     // activate
     void proposal_to_periods( const name proposal_name, const name ram_payer );
-    void check_min_time_voting_end( const time_point_sec start_voting_period );
+    void check_min_time_voting_end( );
     void check_draft_proposal_exists( const name proposer, const name proposal_name );
     void deduct_proposal_activate_fee( const name proposer );
-    void emplace_proposal_from_draft( const name proposer, const name proposal_name, const time_point_sec start_voting_period, const name ram_payer );
+    void emplace_proposal_from_draft( const name proposer, const name proposal_name, const bool activate_next, const name ram_payer );
     void emplace_empty_votes( const name proposal_name, const name ram_payer );
-    void check_start_vote_period( const time_point_sec start_voting_period );
     void check_eligible_proposer( const name proposer );
     void check_max_number_proposals();
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -54,7 +54,7 @@ cleos system newaccount eosio mybp5 EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYq
 # transfer tokens
 cleos transfer eosio myaccount "1000.0000 EOS"
 cleos transfer eosio toaccount "1000.0000 EOS"
-cleos transfer eosio eosio.names "50000.0000 EOS"
+cleos transfer eosio eosio.names "100000.0000 EOS"
 
 # WPS Contract
 cleos system newaccount eosio eosio.wps EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV --stake-cpu "100.0000 EOS" --stake-net "100.0000 EOS" --buy-ram-bytes 2097152  --transfer

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -52,8 +52,8 @@ cleos system newaccount eosio mybp4 EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYq
 cleos system newaccount eosio mybp5 EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV --stake-cpu "100.0000 EOS" --stake-net "100.0000 EOS" --buy-ram-kbytes 8 --transfer
 
 # transfer tokens
-cleos transfer eosio myaccount "1000.0000 EOS"
-cleos transfer eosio toaccount "1000.0000 EOS"
+cleos transfer eosio myaccount "2000.0000 EOS"
+cleos transfer eosio toaccount "2000.0000 EOS"
 cleos transfer eosio eosio.names "100000.0000 EOS"
 
 # WPS Contract

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -20,6 +20,7 @@ cleos -v push action eosio.wps submitdraft '["toaccount", "short", "Short WPS", 
 cleos -v push action eosio.wps submitdraft '["toaccount", "novote", "No Vote WPS", "500.0000 EOS", 1, [{"key":"category", "value":"novote"}]]' -p toaccount
 cleos -v push action eosio.wps submitdraft '["toaccount", "optional", "Optional Vote WPS", "500.0000 EOS", 1, [{"key":"category", "value":"optional"}]]' -p toaccount
 cleos -v push action eosio.wps submitdraft '["myaccount", "large", "My WPS", "20000.0000 EOS", 1, [{"key":"category", "value":"large"}]]' -p myaccount
+cleos -v push action eosio.wps submitdraft '["myaccount", "pending", "My Pending WPS", "24500.0000 EOS", 1, [{"key":"category", "value":"pending"}]]' -p myaccount
 
 # # cancel draft
 # cleos -v push action eosio.wps canceldraft '["myaccount", "mywps"]' -p myaccount
@@ -28,18 +29,19 @@ cleos -v push action eosio.wps submitdraft '["myaccount", "large", "My WPS", "20
 # cleos -v push action eosio.wps modifydraft '["myaccount", "mywps", "My WPS", [{"key":"category", "value":"other"}]]' -p myaccount
 
 # deposit EOS into account
-cleos -v transfer myaccount eosio.wps "200.0000 EOS" ""
-cleos -v transfer toaccount eosio.wps "400.0000 EOS" ""
+cleos -v transfer myaccount eosio.wps "500.0000 EOS" ""
+cleos -v transfer toaccount eosio.wps "500.0000 EOS" ""
 
 # # refund
 # cleos -v push action eosio.wps refund '["myaccount"]' -p myaccount
 
 # activate
-cleos -v push action eosio.wps activate '["myaccount", "mywps", null]' -p myaccount
-cleos -v push action eosio.wps activate '["toaccount", "towps", null]' -p toaccount
-cleos -v push action eosio.wps activate '["toaccount", "short", null]' -p toaccount
-cleos -v push action eosio.wps activate '["toaccount", "novote", null]' -p toaccount
-cleos -v push action eosio.wps activate '["myaccount", "large", null]' -p myaccount
+cleos -v push action eosio.wps activate '["myaccount", "mywps", false]' -p myaccount
+cleos -v push action eosio.wps activate '["toaccount", "towps", false]' -p toaccount
+cleos -v push action eosio.wps activate '["toaccount", "short", false]' -p toaccount
+cleos -v push action eosio.wps activate '["toaccount", "novote", false]' -p toaccount
+cleos -v push action eosio.wps activate '["myaccount", "large", false]' -p myaccount
+cleos -v push action eosio.wps activate '["myaccount", "pending", true]' -p myaccount
 
 # # cancel
 # cleos -v push action eosio.wps canceldraft '["myaccount", "mywps"]' -p myaccount

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,8 +2,8 @@
 
 
 # init, fund & start
-cleos transfer eosio.names eosio.wps "25000.0000 EOS"
-cleos -v push action eosio.wps init '[{"vote_margin": 2, "deposit_required": "100.0000 EOS", "voting_interval": 2592000, "max_monthly_budget": "25000.0000 EOS", "min_time_voting_end": 0 }]' -p eosio.wps
+cleos transfer eosio.names eosio.wps "50000.0000 EOS"
+cleos -v push action eosio.wps init '[{"vote_margin": 2, "deposit_required": "100.0000 EOS", "voting_interval": 5, "max_monthly_budget": "25000.0000 EOS", "min_time_voting_end": 0 }]' -p eosio.wps
 
 # setparams
 # 1 day   = 86400
@@ -19,7 +19,7 @@ cleos -v push action eosio.wps submitdraft '["toaccount", "towps", "To WPS", "20
 cleos -v push action eosio.wps submitdraft '["toaccount", "short", "Short WPS", "800.0000 EOS", 1, [{"key":"category", "value":"short"}]]' -p toaccount
 cleos -v push action eosio.wps submitdraft '["toaccount", "novote", "No Vote WPS", "500.0000 EOS", 1, [{"key":"category", "value":"novote"}]]' -p toaccount
 cleos -v push action eosio.wps submitdraft '["toaccount", "optional", "Optional Vote WPS", "500.0000 EOS", 1, [{"key":"category", "value":"optional"}]]' -p toaccount
-cleos -v push action eosio.wps submitdraft '["myaccount", "large", "My WPS", "24500.0000 EOS", 1, [{"key":"category", "value":"large"}]]' -p myaccount
+cleos -v push action eosio.wps submitdraft '["myaccount", "large", "My WPS", "20000.0000 EOS", 1, [{"key":"category", "value":"large"}]]' -p myaccount
 
 # # cancel draft
 # cleos -v push action eosio.wps canceldraft '["myaccount", "mywps"]' -p myaccount

--- a/src/activate.cpp
+++ b/src/activate.cpp
@@ -2,7 +2,6 @@
 void wps::activate( const name proposer, const name proposal_name, bool activate_next )
 {
     require_auth( proposer );
-    const name ram_payer = get_self();
 
     // is contract paused or not
     check_contract_active();
@@ -31,13 +30,13 @@ void wps::activate( const name proposer, const name proposal_name, bool activate
     deduct_proposal_activate_fee( proposer );
 
     // create proposal
-    emplace_proposal_from_draft( proposer, proposal_name, activate_next, ram_payer );
+    emplace_proposal_from_draft( proposer, proposal_name, activate_next );
 
     // add empty votes for proposal
-    emplace_empty_votes( proposal_name, ram_payer );
+    emplace_empty_votes( proposal_name );
 
     // add proposal name to time periods
-    if ( !activate_next ) proposal_to_periods( proposal_name, ram_payer );
+    if ( !activate_next ) add_proposal_to_periods( proposal_name );
 }
 
 void wps::check_min_time_voting_end()
@@ -46,32 +45,6 @@ void wps::check_min_time_voting_end()
     auto settings = _settings.get();
     const time_point end_voting_period = time_point( state.current_voting_period ) + time_point_sec( settings.voting_interval );
     check( current_time_point() + time_point_sec( settings.min_time_voting_end ) < end_voting_period, "cannot activate within " + to_string( settings.min_time_voting_end ) + " seconds of next voting period ending");
-}
-
-void wps::proposal_to_periods( const name proposal_name, const name ram_payer )
-{
-    // settings
-    auto settings = _settings.get();
-    auto proposals_itr = _proposals.find( proposal_name.value );
-
-    // insert proposal name into multiple periods
-    for (int i = 0; i < proposals_itr->duration; i++) {
-        const time_point_sec voting_period = time_point(proposals_itr->start_voting_period) + time_point_sec(settings.voting_interval * i);
-        auto periods_itr = _periods.find( voting_period.sec_since_epoch() );
-
-        // create new set of proposals
-        if ( periods_itr == _periods.end() ) {
-            _periods.emplace( ram_payer, [&]( auto& row ) {
-                row.voting_period   = voting_period;
-                row.proposals       = set<name> { proposal_name };
-            });
-        // insert proposal to old ones
-        } else {
-            _periods.modify( periods_itr, ram_payer, [&]( auto& row ) {
-                row.proposals.insert( proposal_name );
-            });
-        }
-    }
 }
 
 void wps::check_draft_proposal_exists( const name proposer, const name proposal_name )
@@ -100,9 +73,10 @@ void wps::deduct_proposal_activate_fee( const name proposer )
     move_to_locked_deposits( settings.deposit_required );
 }
 
-void wps::emplace_proposal_from_draft( const name proposer, const name proposal_name, const bool activate_next, const name ram_payer )
+void wps::emplace_proposal_from_draft( const name proposer, const name proposal_name, const bool activate_next )
 {
     // settings
+    const name ram_payer = get_self();
     auto settings = _settings.get();
     auto state = _state.get();
     drafts_table _drafts( get_self(), proposer.value );
@@ -137,8 +111,10 @@ void wps::emplace_proposal_from_draft( const name proposer, const name proposal_
     _drafts.erase( drafts_itr );
 }
 
-void wps::emplace_empty_votes( const name proposal_name, const name ram_payer )
+void wps::emplace_empty_votes( const name proposal_name )
 {
+    const name ram_payer = get_self();
+
     // empty votes for proposal
     auto votes_itr = _votes.find( proposal_name.value );
 
@@ -153,11 +129,4 @@ void wps::check_eligible_proposer( const name proposer )
 {
     eosiosystem::producers_table _producers( "eosio"_n, "eosio"_n.value );
     check( _producers.find( proposer.value ) == _producers.end(), "[proposer] cannot be a registered producer");
-}
-
-void wps::check_max_number_proposals()
-{
-    auto periods_itr = _periods.find( _state.get().current_voting_period.sec_since_epoch() );
-    if ( periods_itr == _periods.end() ) return; // skip if no proposals in current period
-    check(periods_itr->proposals.size() <= 100, "cannot exceed 100 proposals per single voting period");
 }

--- a/src/activate.cpp
+++ b/src/activate.cpp
@@ -1,8 +1,8 @@
 [[eosio::action]]
-void wps::activate( const eosio::name proposer, const eosio::name proposal_name, std::optional<eosio::time_point_sec> start_voting_period )
+void wps::activate( const name proposer, const name proposal_name, bool activate_next )
 {
     require_auth( proposer );
-    const eosio::name ram_payer = get_self();
+    const name ram_payer = get_self();
 
     // is contract paused or not
     check_contract_active();
@@ -18,20 +18,11 @@ void wps::activate( const eosio::name proposer, const eosio::name proposal_name,
     // prevents excessive execute time for processing large amounts of proposals
     check_max_number_proposals();
 
-    // [optional] start voting period
-    eosio::time_point_sec voting_period = time_point_sec( start_voting_period->sec_since_epoch() );
-
-    // set start voting period to current voting period if defined as null
-    if ( start_voting_period->sec_since_epoch() == 0 ) voting_period = _state.get().current_voting_period;
-
-    // voting period must be current or next
-    check_start_vote_period( voting_period );
-
     // cannot activate during completed voting period phase
     check_voting_period_completed();
 
     // minimum time required to activate at the end of the current voting period
-    check_min_time_voting_end( voting_period );
+    if ( !activate_next ) check_min_time_voting_end( );
 
     // can't create proposal that already exists
     check_draft_proposal_exists( proposer, proposal_name );
@@ -40,23 +31,24 @@ void wps::activate( const eosio::name proposer, const eosio::name proposal_name,
     deduct_proposal_activate_fee( proposer );
 
     // create proposal
-    emplace_proposal_from_draft( proposer, proposal_name, voting_period, ram_payer );
+    emplace_proposal_from_draft( proposer, proposal_name, activate_next, ram_payer );
 
     // add empty votes for proposal
     emplace_empty_votes( proposal_name, ram_payer );
 
     // add proposal name to time periods
-    proposal_to_periods( proposal_name, ram_payer );
+    if ( !activate_next ) proposal_to_periods( proposal_name, ram_payer );
 }
 
-void wps::check_min_time_voting_end( const eosio::time_point_sec start_voting_period )
+void wps::check_min_time_voting_end()
 {
+    auto state = _state.get();
     auto settings = _settings.get();
-    const time_point end_voting_period = time_point( start_voting_period ) + time_point_sec(settings.voting_interval);
-    check( current_time_point() + time_point_sec( settings.min_time_voting_end ) < end_voting_period, "cannot activate within " + to_string(settings.min_time_voting_end) + " seconds of next voting period ending");
+    const time_point end_voting_period = time_point( state.current_voting_period ) + time_point_sec( settings.voting_interval );
+    check( current_time_point() + time_point_sec( settings.min_time_voting_end ) < end_voting_period, "cannot activate within " + to_string( settings.min_time_voting_end ) + " seconds of next voting period ending");
 }
 
-void wps::proposal_to_periods( const eosio::name proposal_name, const eosio::name ram_payer )
+void wps::proposal_to_periods( const name proposal_name, const name ram_payer )
 {
     // settings
     auto settings = _settings.get();
@@ -64,14 +56,14 @@ void wps::proposal_to_periods( const eosio::name proposal_name, const eosio::nam
 
     // insert proposal name into multiple periods
     for (int i = 0; i < proposals_itr->duration; i++) {
-        const eosio::time_point_sec voting_period = time_point(proposals_itr->start_voting_period) + time_point_sec(settings.voting_interval * i);
+        const time_point_sec voting_period = time_point(proposals_itr->start_voting_period) + time_point_sec(settings.voting_interval * i);
         auto periods_itr = _periods.find( voting_period.sec_since_epoch() );
 
         // create new set of proposals
         if ( periods_itr == _periods.end() ) {
             _periods.emplace( ram_payer, [&]( auto& row ) {
                 row.voting_period   = voting_period;
-                row.proposals       = std::set<eosio::name> { proposal_name };
+                row.proposals       = set<name> { proposal_name };
             });
         // insert proposal to old ones
         } else {
@@ -82,7 +74,7 @@ void wps::proposal_to_periods( const eosio::name proposal_name, const eosio::nam
     }
 }
 
-void wps::check_draft_proposal_exists( const eosio::name proposer, const eosio::name proposal_name )
+void wps::check_draft_proposal_exists( const name proposer, const name proposal_name )
 {
     // get scoped draft
     drafts_table _drafts( get_self(), proposer.value );
@@ -97,7 +89,7 @@ void wps::check_draft_proposal_exists( const eosio::name proposer, const eosio::
     check( proposals_itr == _proposals.end(), "[proposal_name] unfortunately already exists, please `canceldraft` and use a different proposal name");
 }
 
-void wps::deduct_proposal_activate_fee( const eosio::name proposer )
+void wps::deduct_proposal_activate_fee( const name proposer )
 {
     auto settings = _settings.get();
 
@@ -108,7 +100,7 @@ void wps::deduct_proposal_activate_fee( const eosio::name proposer )
     move_to_locked_deposits( settings.deposit_required );
 }
 
-void wps::emplace_proposal_from_draft( const eosio::name proposer, const eosio::name proposal_name, const eosio::time_point_sec start_voting_period, const eosio::name ram_payer )
+void wps::emplace_proposal_from_draft( const name proposer, const name proposal_name, const bool activate_next, const name ram_payer )
 {
     // settings
     auto settings = _settings.get();
@@ -129,8 +121,7 @@ void wps::emplace_proposal_from_draft( const eosio::name proposer, const eosio::
         row.proposal_json       = drafts_itr->proposal_json;
 
         // active/pending status
-        if ( start_voting_period == time_point(state.current_voting_period) ) row.status = "active"_n;
-        else row.status = "pending"_n;
+        row.status = activate_next ? "pending"_n : "active"_n;
 
         // extras
         row.total_net_votes             = 0;
@@ -138,7 +129,7 @@ void wps::emplace_proposal_from_draft( const eosio::name proposer, const eosio::
         row.payouts                     = asset{0, symbol{"EOS", 4}};
         row.claimed                     = asset{0, symbol{"EOS", 4}};
         row.created                     = current_time_point();
-        row.start_voting_period         = start_voting_period;
+        row.start_voting_period         = activate_next ? time_point_sec(0) : state.current_voting_period;
         row.remaining_voting_periods    = drafts_itr->duration;
     });
 
@@ -146,7 +137,7 @@ void wps::emplace_proposal_from_draft( const eosio::name proposer, const eosio::
     _drafts.erase( drafts_itr );
 }
 
-void wps::emplace_empty_votes( const eosio::name proposal_name, const eosio::name ram_payer )
+void wps::emplace_empty_votes( const name proposal_name, const name ram_payer )
 {
     // empty votes for proposal
     auto votes_itr = _votes.find( proposal_name.value );
@@ -156,12 +147,6 @@ void wps::emplace_empty_votes( const eosio::name proposal_name, const eosio::nam
     _votes.emplace( ram_payer, [&]( auto& row ) {
         row.proposal_name = proposal_name;
     });
-}
-
-void wps::check_start_vote_period( const eosio::time_point_sec start_voting_period )
-{
-    auto state = _state.get();
-    check( start_voting_period == state.current_voting_period || start_voting_period == state.next_voting_period, "[start_voting_period] must equal to [current_voting_period] or [next_voting_period]");
 }
 
 void wps::check_eligible_proposer( const name proposer )

--- a/src/activate.cpp
+++ b/src/activate.cpp
@@ -132,9 +132,6 @@ void wps::emplace_proposal_from_draft( const eosio::name proposer, const eosio::
         if ( start_voting_period == time_point(state.current_voting_period) ) row.status = "active"_n;
         else row.status = "pending"_n;
 
-        // remaining_voting_periods uses duration to set initial value
-        const int16_t remaining_voting_periods = row.status == "active"_n ? drafts_itr->duration - 1 : drafts_itr->duration;
-
         // extras
         row.total_net_votes             = 0;
         row.eligible                    = false;
@@ -142,7 +139,7 @@ void wps::emplace_proposal_from_draft( const eosio::name proposer, const eosio::
         row.claimed                     = asset{0, symbol{"EOS", 4}};
         row.created                     = current_time_point();
         row.start_voting_period         = start_voting_period;
-        row.remaining_voting_periods    = remaining_voting_periods;
+        row.remaining_voting_periods    = drafts_itr->duration;
     });
 
     // erase draft

--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -22,11 +22,12 @@ void wps::complete( )
     // payouts of active proposals
     handle_payouts();
 
+    // update current & next voting period
+    update_to_next_voting_period();
+
     // set pending proposals to active status
     set_pending_to_active();
 
-    // update current & next voting period
-    update_to_next_voting_period();
 }
 
 bool wps::is_voting_period_complete()
@@ -145,6 +146,7 @@ void wps::set_pending_to_active()
 
         _proposals.modify( proposals_itr, same_payer, [&]( auto& row ) {
             row.status = "active"_n;
+            row.start_voting_period = _state.get().current_voting_period;
         });
     }
 }

--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -39,8 +39,16 @@ void wps::update_to_next_voting_period()
     auto state = _state.get();
     auto settings = _settings.get();
 
-    state.current_voting_period = state.next_voting_period;
-    state.next_voting_period = state.next_voting_period + settings.voting_interval;
+    // // UNCOMMENT FOR PRODUCTION
+    // // start of voting period will start at the nearest 00:00UTC
+    // const uint64_t now = current_time_point().sec_since_epoch();
+    // const time_point_sec current_voting_period = time_point_sec(now - now % DAY);
+
+    if ( TESTING ) print("set `current_voting_period` to now");
+    const time_point_sec current_voting_period = current_time_point();
+
+    state.current_voting_period = current_voting_period;
+    state.next_voting_period = state.current_voting_period + settings.voting_interval;
     _state.set( state, same_payer );
 }
 

--- a/src/complete.cpp
+++ b/src/complete.cpp
@@ -22,6 +22,9 @@ void wps::complete( )
     // payouts of active proposals
     handle_payouts();
 
+    // copy current proposals to next period
+    copy_current_to_next_periods();
+
     // update current & next voting period
     update_to_next_voting_period();
 
@@ -40,13 +43,10 @@ void wps::update_to_next_voting_period()
     auto state = _state.get();
     auto settings = _settings.get();
 
-    // // UNCOMMENT FOR PRODUCTION
-    // // start of voting period will start at the nearest 00:00UTC
-    // const uint64_t now = current_time_point().sec_since_epoch();
-    // const time_point_sec current_voting_period = time_point_sec(now - now % DAY);
-
-    if ( TESTING ) print("set `current_voting_period` to now");
-    const time_point_sec current_voting_period = current_time_point();
+    // start of voting period will start at the nearest 00:00UTC
+    const uint64_t now = current_time_point().sec_since_epoch();
+    time_point_sec current_voting_period = time_point_sec(now - now % DAY);
+    if ( TESTING ) current_voting_period = current_time_point();
 
     state.current_voting_period = current_voting_period;
     state.next_voting_period = state.current_voting_period + settings.voting_interval;
@@ -148,6 +148,7 @@ void wps::set_pending_to_active()
             row.status = "active"_n;
             row.start_voting_period = _state.get().current_voting_period;
         });
+        add_proposal_to_periods( proposal_name );
     }
 }
 
@@ -156,3 +157,4 @@ void wps::check_voting_period_completed()
     auto state = _state.get();
     check( current_time_point() < time_point( state.next_voting_period ), "[current_voting_period] is completed, any account must execute [complete] ACTION to continue");
 }
+

--- a/src/eosio.wps.cpp
+++ b/src/eosio.wps.cpp
@@ -15,3 +15,4 @@
 #include "claims.cpp"
 #include "refresh.cpp"
 #include "comments.cpp"
+#include "periods.cpp"

--- a/src/periods.cpp
+++ b/src/periods.cpp
@@ -1,0 +1,54 @@
+void wps::check_max_number_proposals()
+{
+    auto periods_itr = _periods.find( _state.get().current_voting_period.sec_since_epoch() );
+    if ( periods_itr == _periods.end() ) return; // skip if no proposals in current period
+    check(periods_itr->proposals.size() <= 100, "cannot exceed 100 proposals per single voting period");
+}
+
+void wps::add_proposal_to_periods( const name proposal_name )
+{
+    const name ram_payer = get_self();
+    auto state = _state.get();
+    auto periods_itr = _periods.find( state.current_voting_period.sec_since_epoch() );
+
+    // create new set of proposals
+    if ( periods_itr == _periods.end() ) {
+        _periods.emplace( ram_payer, [&]( auto& row ) {
+            row.voting_period   = state.current_voting_period;
+            row.proposals       = set<name> { proposal_name };
+        });
+    // insert proposal to old ones
+    } else {
+        _periods.modify( periods_itr, ram_payer, [&]( auto& row ) {
+            row.proposals.insert( proposal_name );
+        });
+    }
+}
+
+void wps::copy_current_to_next_periods()
+{
+    const name ram_payer = get_self();
+    auto state = _state.get();
+    auto settings = _settings.get();
+
+    // must calculate next_voting_period in case the next period has been changed caused by delayed complete action
+    // cannot use `state.next_voting_period`
+    const time_point_sec next_voting_period = current_time_point() + time_point_sec( settings.voting_interval );
+
+    // lookup iterators
+    auto current_periods_itr = _periods.find( state.current_voting_period.sec_since_epoch() );
+    auto next_periods_itr = _periods.find( next_voting_period.sec_since_epoch() );
+
+    // create new set of proposals
+    if ( next_periods_itr == _periods.end() ) {
+        _periods.emplace( ram_payer, [&]( auto& row ) {
+            row.voting_period   = next_voting_period;
+            row.proposals       = current_periods_itr->proposals;
+        });
+    // insert proposal to old ones
+    } else {
+        _periods.modify( next_periods_itr, ram_payer, [&]( auto& row ) {
+            row.proposals = current_periods_itr->proposals;
+        });
+    }
+}

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -15,9 +15,13 @@ void wps::init( const wps_parameters params )
     auto state = _state.get_or_default();
     state.available_funding = token::get_balance( BUDGET_TOKEN_CONTRACT, get_self(), BUDGET_SYMBOL.code() );
 
-    // start of voting period will start at the nearest 00:00UTC
-    const uint64_t now = current_time_point().sec_since_epoch();
-    const time_point_sec current_voting_period = time_point_sec(now - now % DAY);
+    // // UNCOMMENT FOR PRODUCTION
+    // // start of voting period will start at the nearest 00:00UTC
+    // const uint64_t now = current_time_point().sec_since_epoch();
+    // const time_point_sec current_voting_period = time_point_sec(now - now % DAY);
+
+    if ( TESTING ) print("set `current_voting_period` to now");
+    const time_point_sec current_voting_period = current_time_point();
 
     // define `state`
     state.current_voting_period = current_voting_period;
@@ -39,7 +43,9 @@ void wps::setparams( const wps_parameters params )
 
 void wps::check_wps_parameters( const wps_parameters params )
 {
-    check( params.voting_interval == MONTH, "[voting_interval] must equal to 30 days (2592000)");
+    if ( TESTING ) print("removed `voting_interval` check");
+    // // UNCOMMENT FOR PRODUCTION
+    // check( params.voting_interval == MONTH, "[voting_interval] must equal to 30 days (2592000)");
     check( params.deposit_required.symbol == BUDGET_SYMBOL, "[deposit_required] invalid symbol");
     check( params.max_monthly_budget.symbol == BUDGET_SYMBOL, "[max_monthly_budget] invalid symbol");
     check( params.deposit_required.amount >= 0, "[deposit_required] must be positive");

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -15,13 +15,11 @@ void wps::init( const wps_parameters params )
     auto state = _state.get_or_default();
     state.available_funding = token::get_balance( BUDGET_TOKEN_CONTRACT, get_self(), BUDGET_SYMBOL.code() );
 
-    // // UNCOMMENT FOR PRODUCTION
-    // // start of voting period will start at the nearest 00:00UTC
-    // const uint64_t now = current_time_point().sec_since_epoch();
-    // const time_point_sec current_voting_period = time_point_sec(now - now % DAY);
+    // start of voting period will start at the nearest 00:00UTC
+    const uint64_t now = current_time_point().sec_since_epoch();
+    time_point_sec current_voting_period = time_point_sec(now - now % DAY);
 
-    if ( TESTING ) print("set `current_voting_period` to now");
-    const time_point_sec current_voting_period = current_time_point();
+    if ( TESTING ) current_voting_period = current_time_point();
 
     // define `state`
     state.current_voting_period = current_voting_period;
@@ -43,9 +41,7 @@ void wps::setparams( const wps_parameters params )
 
 void wps::check_wps_parameters( const wps_parameters params )
 {
-    if ( TESTING ) print("removed `voting_interval` check");
-    // // UNCOMMENT FOR PRODUCTION
-    // check( params.voting_interval == MONTH, "[voting_interval] must equal to 30 days (2592000)");
+    if ( !TESTING ) check( params.voting_interval == MONTH, "[voting_interval] must equal to 30 days (2592000)");
     check( params.deposit_required.symbol == BUDGET_SYMBOL, "[deposit_required] invalid symbol");
     check( params.max_monthly_budget.symbol == BUDGET_SYMBOL, "[max_monthly_budget] invalid symbol");
     check( params.deposit_required.amount >= 0, "[deposit_required] must be positive");


### PR DESCRIPTION
#### `remaining_voting_periods` major change

- [x] replace `end` value with `remaining_voting_periods` in `proposals` TABLE
- [x] `remaining_voting_periods` number represents how many remaining of voting periods the proposal has.
- [x] when proposal `activate` the `remaining_voting_periods` is set to the `duration` (for both active & pending proposals)
- [x] whenever `complete` is executed, all `active` proposals will reduce -1 the `remaining_voting_periods`, `pending` proposals are unchanged.
- [x] any proposals that have 0 duration are set to either `completed`/`expired`/`partial`
- [x] replace `start_voting_period` from `activate()` and replace with `bool activate_next`
- [x] don't add future or past proposals to `periods`
- [x] when `complete` add all `active` & `pending` proposal names to `periods`
- [x] only include `pending` proposals to `periods` when active
- [x] set `start_voting_period` = 0 for `pending` proposals
- [x] when `complete` update current & next voting periods to 0:00 UTC (in case multiple days/weeks are skipped, the current voting period will be set to the day the last `complete` is executed).
- [x] set `start_voting_period` for proposals changing from `pending` => `active`

#### Breaking UI changes

- replace `start_voting_period` from `activate()` ACTION and replace with `bool activate_next` (true = activate next, false = active current)
- replace `end` value with `remaining_voting_periods` in `proposals` TABLE
- `remaining_voting_periods` number represents how many remaining of voting periods the proposal has.
